### PR TITLE
set default for optional inputs

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -19,6 +19,7 @@
       "label": "OPTIONAL select if you want to run MultiQC on a single data folder",
       "help": "only and all files in project:/folder/* will be downloaded and passed to MultiQC ",
       "optional": true,
+      "default": false,
       "class": "boolean"
     },
     {
@@ -47,6 +48,7 @@
       "label": "OPTIONAL Do you want target bases coverage to be calculated at 200, 250, 300, 500 and 1000x?",
       "help": "otherwise restricted to %coverage at 1, 2, 10, 20, 30, 40, 50 and 100x",
       "optional": true,
+      "default": false,
       "class": "boolean"
     }
   ],


### PR DESCRIPTION
optional inputs needed to have a default value 'false' to work correctly.
Re-built and tested again on DNAnexus: for an example [Dias](https://platform.dnanexus.com/projects/FpG6k2Q4g59bZJ0z15XzByFY/monitor/job/Fz35VY04g59pfg11BV7B950Z) gemini run and a single folder of [myeloid](https://platform.dnanexus.com/projects/FpG6k2Q4g59bZJ0z15XzByFY/monitor/job/Fz35XBj4g59Zzvj8PkFVGBP1) data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc/20)
<!-- Reviewable:end -->
