### PR TITLE
Multiqc interop

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -5,9 +5,6 @@
   "dxapi": "1.0.0",
   "version": "3.1.0",
   "openSource": true,
-  "properties": {
-    "githubRelease": "v3.0.0"
-  },
   "inputSpec": [
     {
       "name": "multiqc_docker",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
-  "name": "eggd_MultiQC_interop",
-  "title": "eggd_MultiQC_interop",
+  "name": "eggd_MultiQC",
+  "title": "eggd_MultiQC",
   "summary": "MultiQC -  Generates a run-wide visualisation of QC reports",
   "dxapi": "1.0.0",
   "version": "3.1.0",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,9 +1,9 @@
 {
-  "name": "eggd_MultiQC",
-  "title": "eggd_MultiQC",
+  "name": "eggd_MultiQC_interop",
+  "title": "eggd_MultiQC_interop",
   "summary": "MultiQC -  Generates a run-wide visualisation of QC reports",
   "dxapi": "1.0.0",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "openSource": true,
   "properties": {
     "githubRelease": "v3.0.0"

--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -64,11 +64,6 @@ main() {
             ;;
     esac
 
-
-    # Define 001_staging_area52
-    staging_area="project-FpVG0G84X7kzq58g19vF1YJQ"
-    interOp_location="250425_A01303_0546_BHY2MMDRX5"
-
     # Remove 002_ from the beginning of the project name
     project=${project#"002_"}
     # Remove '_clinicalgenetics' from the end of the project name

--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -34,7 +34,7 @@ main() {
         dx find data --brief --path "$workflowdir" --name "$pattern"  >> input_files.txt
     done
 
-    cat input_files.txt | xargs -P$(nproc --all) -n1 -I{} dx download {} -o ./inputs/
+    cat input_files.txt | xargs -P$(nproc --all) -n1 -I{} dx download -f {} -o ./inputs/
 
     # Download all /demultiplex_multiqc_files
     echo "Looking for files in /demultiplex_multiqc_files"
@@ -46,7 +46,7 @@ main() {
         # Fetch and download InterOp files in parallel
         dx find data --brief --path "$demultiplex_multiqc_files_directory" \
           | tee -a input_files.txt \
-          | xargs -P$(nproc --all) -n1 -I{} dx download {} -o ./inputs/
+          | xargs -P$(nproc --all) -n1 -I{} dx download -f {} -o ./inputs/
     else
         echo "No files found in /demultiplex_multiqc_files"
     fi

--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -73,6 +73,41 @@ main() {
     report_outdir=out/multiqc_html_report && mkdir -p ${report_outdir}
     outdir=out/multiqc_data_files && mkdir -p ${outdir}
 
+    # Define 001_staging_area52
+    staging_area="project-FpVG0G84X7kzq58g19vF1YJQ"
+    mkdir -p interop_pkg
+    tar -xvjf ~/illumina-interop-1.4.0-h503566f_0.tar.bz2 -C interop_pkg
+    # Add interop_pkg/bin to path
+    export PATH="$PWD/interop_pkg/bin:$PATH"
+
+
+    # Find InterOp and RunInfo files
+    interop_files=$(dx find data --brief --path "${interop_project}:/${folder_name}/" --name "InterOp.tar.gz")
+    run_xml=$(dx find data --brief --path "${interop_project}:/${folder_name}/" --name "RunInfo.xml")
+
+    # Download InterOp and RunInfo files
+    if [[ ! -z "$interop_files" ]]; then
+        echo "Downloading InterOp binary files"
+        echo "$interop_files" | xargs -P$(nproc --all) -n1 -I{} dx download {} -o ./inputs/ --overwrite
+        echo "$run_xml" | xargs -P$(nproc --all) -n1 -I{} dx download {} -o ./inputs/ --overwrite
+
+    else
+        echo "No InterOp files found in ${interop_project}:/${folder_name}"
+    fi
+
+    # Run interop_summary and interop_index-summary
+    if [[ -f inputs/InterOp.tar.gz ]]; then
+        echo "Extracting InterOp.tar.gz"
+        tar -xzf inputs/InterOp.tar.gz -C inputs/
+
+        echo "Generating InterOp summary CSV files"
+        interop_summary --csv=1 inputs/ > inputs/interop_summary.csv || echo "interop_summary failed"
+        interop_index-summary --csv=1 inputs/ > inputs/interop_index_summary.csv || echo "interop_index-summary failed"
+    else
+        echo "No InterOp.tar.gz file to extract"
+    fi
+
+
     echo "Running MultiQC on the downloaded QC metric files"
     # Load the docker image and then run it
     docker load -i MultiQC.tar.gz

--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -43,7 +43,10 @@ main() {
     # Check if the directory exists and contains any files
     if dx find data --path "$demultiplex_multiqc_files_directory" --brief | grep -q .; then
         echo "Downloading files from $demultiplex_multiqc_files_directory"
-        dx find data --brief --path "$demultiplex_multiqc_files_directory" >> input_files.txt
+        # Fetch and download InterOp files in parallel
+        dx find data --brief --path "$demultiplex_multiqc_files_directory" \
+          | tee -a input_files.txt \
+          | xargs -P$(nproc --all) -n1 -I{} dx download {} -o ./inputs/
     else
         echo "No files found in /demultiplex_multiqc_files"
     fi


### PR DESCRIPTION
Removed the code that reads in Stats.json and replaced it with a short code that takes in all of the contents of demultiplex_multiqc_files_directory, to allow for InterOp .csv files to be used as inputs to MultiQC

Increased version to 3.1.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc/45)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The script now automatically detects and downloads all files from the "/demultiplex_multiqc_files" directory if available.
- **Chores**
	- Updated the app version to 3.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->