### PR TITLE
Included the search of project/output/primary if project/primary was …

### DIFF
--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -20,14 +20,15 @@ main() {
     touch input_files.txt
 
     echo "Download all QC metrics from the folders specified in the config file"
-
-    if [[ $(dx find data --path "$project:$primary" --brief) ]]; then
+    if [[ $(dx find data --path "${project}:/$primary") ]]; then
         # found data in specified dir => use it
         workflowdir="$project:/$primary"
+    elif [[ $(dx find data --path "${project}:/output/${primary}") ]]; then
+        # dir specified without output prefix
+        workflowdir="$project:/output/${primary}"
     else
         dx-jobutil-report-error "Given primary output directory does not contain data"
     fi
-
     # get all file patterns of files to download from primary workflow output folder,
     # then find and download from project in given folder
     for pattern in $(~/yq_4.45.1 -r '.["dx_sp"].["primary"].[] | flatten | join(" ")' config.yaml); do

--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -20,10 +20,10 @@ main() {
     touch input_files.txt
 
     echo "Download all QC metrics from the folders specified in the config file"
-    if [[ $(dx find data --path "${project}:/$primary") ]]; then
+    if dx find data --path "${project}:/$primary" --brief; then
         # found data in specified dir => use it
         workflowdir="$project:/$primary"
-    elif [[ $(dx find data --path "${project}:/output/${primary}") ]]; then
+    elif dx find data --path "${project}:/output/${primary}" --brief; then
         # dir specified without output prefix
         workflowdir="$project:/output/${primary}"
     else


### PR DESCRIPTION
Added the code:

```
    elif [[ $(dx find data --path "${project}:/output/${primary}") ]]; then
        # dir specified without output prefix
        workflowdir="$project:/output/${primary}"
```

This elif statement ensures that eggd_multiqc can access the appropriate folder if it is in the format /output/primary

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc/46)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of the workflow output directory by adding an additional fallback path, reducing errors when locating workflow results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->