### PR TITLE
Corrected the logic behind finding data

### DIFF
--- a/src/multiqc.sh
+++ b/src/multiqc.sh
@@ -20,10 +20,10 @@ main() {
     touch input_files.txt
 
     echo "Download all QC metrics from the folders specified in the config file"
-    if dx find data --path "${project}:/$primary" --brief; then
+    if [[ $(dx find data --path "${project}:/$primary") ]]; then
         # found data in specified dir => use it
         workflowdir="$project:/$primary"
-    elif dx find data --path "${project}:/output/${primary}" --brief; then
+    elif [[ $(dx find data --path "${project}:/output/${primary}") ]]; then
         # dir specified without output prefix
         workflowdir="$project:/output/${primary}"
     else
@@ -42,7 +42,7 @@ main() {
     demultiplex_multiqc_files_directory="${project}:/demultiplex_multiqc_files"
 
     # Check if the directory exists and contains any files
-    if dx find data --path "$demultiplex_multiqc_files_directory" --brief | grep -q .; then
+    if dx find data --path "$demultiplex_multiqc_files_directory" --brief; then
         echo "Downloading files from $demultiplex_multiqc_files_directory"
         # Fetch and download InterOp files in parallel
         dx find data --brief --path "$demultiplex_multiqc_files_directory" \


### PR DESCRIPTION
The code:
```if dx find data --path "${project}:/$primary" --brief; then ```
is just checking if the dx find data was executing successfully and not the contents of the directory. 

The code:
```if [[ $(dx find data --path "${project}:/$primary") ]]; then```
is actually checking if the directory is empty or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc/47)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way the script checks for the presence of data in specific directories, resulting in clearer and more reliable detection of available files. No changes to user-facing features or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->